### PR TITLE
Bump Elixir version to 1.6.5.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.1" \
+ENV ELIXIR_VERSION="v1.6.5" \
   LANG=C.UTF-8
 
 RUN set -xe \
   && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-  && ELIXIR_DOWNLOAD_SHA256="91109a1774e9040fb10c1692c146c3e5a102e621e9c48196bfea7b828d54544c" \
+  && ELIXIR_DOWNLOAD_SHA256="defe2bed953ee729addf1121db3fa42a618ef1d6c57a1f489da03b0e7a626e89" \
   && buildDeps="ca-certificates curl make" \
   && apk add --no-cache --virtual .build-deps $buildDeps \
   && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/664426497)