### PR TITLE
Update OTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:23.2-alpine
+FROM erlang:23.2.3-alpine
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.11.2" \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 2. Compute the SHA256 digest for the `.tar.gz` file with `sha256sum`. You can also use `shasum -a 256 <filename>` on a Mac.
 3. Update `ELIXIR_VERSION` and `ELIXIR_VERSION_SHA` in `Dockerfile`.
 4. Update the base Erlang version in the `FROM` statement, if appropriate.
-5. Run `docker build -t rentpath/rp_elixir:v1.11.2-alpine-otp-23.2 -t rentpath/rp_elixir:latest .`
-6. Run `docker push rentpath/rp_elixir:v1.11.2-alpine-otp-23.2`
+5. Run `docker build -t rentpath/rp_elixir:v1.11.2-alpine-otp-23.2.3 -t rentpath/rp_elixir:latest .`
+6. Run `docker push rentpath/rp_elixir:v1.11.2-alpine-otp-23.2.3`
 7. Run `docker push rentpath/rp_elixir:latest`


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2794)

This fixes a security vulnerability in OTP 23.2.1.

I only updated the OTP version. Elixir 1.11.3 didn't have a checksum in its GitHub release, so I didn't upgrade Elixir from 1.11.2.